### PR TITLE
feat(seo): add JSON-LD structured data for local SEO

### DIFF
--- a/__tests__/schemas.test.ts
+++ b/__tests__/schemas.test.ts
@@ -1,0 +1,103 @@
+// Validates the JSON-LD structured-data builders.
+// Acts as a fast local check that the markup is well-formed and GBP-consistent
+// before deploying (no Sanity/env needed — these are pure functions).
+
+import {
+  localBusinessSchema,
+  webSiteSchema,
+  serviceSchema,
+  breadcrumbSchema,
+  faqPageSchema,
+  portableTextToPlain,
+} from "@/components/JsonLd/schemas";
+import { LocalPaths } from "@/data.d";
+
+describe("LocalBusiness schema", () => {
+  const schema = localBusinessSchema("en") as Record<string, any>;
+
+  it("declares the right type + GBP-matching name", () => {
+    expect(schema["@type"]).toBe("LocalBusiness");
+    expect(schema.name).toBe("Seto x Arts | Custom LED Wood Signs");
+  });
+
+  it("includes the synced NAP fields", () => {
+    expect(schema.telephone).toBe("+1-438-405-8699");
+    expect(schema.address.addressLocality).toBe("Laval");
+    expect(schema.address.postalCode).toBe("H7R 2B7");
+    expect(schema.geo.latitude).toBeTruthy();
+    expect(schema.foundingDate).toBe("2024-09-01");
+  });
+
+  it("serves the GBP areas including Fabreville", () => {
+    const cities = schema.areaServed.map((a: any) => a.name);
+    expect(cities).toEqual(expect.arrayContaining(["Laval", "Montreal", "Fabreville"]));
+  });
+
+  it("omits empty fields entirely (no blank keys)", () => {
+    for (const value of Object.values(schema)) {
+      expect(value).not.toBe("");
+    }
+  });
+
+  it("is JSON-serializable (valid for ld+json output)", () => {
+    expect(() => JSON.stringify(schema)).not.toThrow();
+  });
+});
+
+describe("Service + WebSite schemas", () => {
+  it("links the service to the business and localizes FR", () => {
+    const en = serviceSchema("en") as Record<string, any>;
+    const fr = serviceSchema("fr") as Record<string, any>;
+    expect(en.serviceType).toMatch(/Custom LED Wood Signs/);
+    expect(fr.serviceType).toMatch(/sur mesure/);
+    expect(en.provider["@id"]).toContain("#business");
+  });
+
+  it("website node references the business as publisher", () => {
+    const site = webSiteSchema("en") as Record<string, any>;
+    expect(site["@type"]).toBe("WebSite");
+    expect(site.publisher["@id"]).toContain("#business");
+  });
+});
+
+describe("Breadcrumb schema", () => {
+  it("numbers items in order with absolute URLs", () => {
+    const bc = breadcrumbSchema("en", [
+      { name: "Home", path: LocalPaths.HOME },
+      { name: "Projects", path: LocalPaths.PROJECTS },
+      { name: "Cafe Sign", path: `${LocalPaths.PROJECTS}/cafe-sign` },
+    ]) as Record<string, any>;
+    expect(bc.itemListElement).toHaveLength(3);
+    expect(bc.itemListElement[0].position).toBe(1);
+    expect(bc.itemListElement[2].item).toContain("/en/projects/cafe-sign");
+  });
+});
+
+describe("FAQPage schema", () => {
+  it("builds Q&A from Portable Text answers", () => {
+    const faq = faqPageSchema([
+      {
+        question: "How long does a sign take?",
+        answer: [
+          { _type: "block", children: [{ text: "Usually 2 to 4 weeks." }] },
+        ],
+      },
+    ]) as Record<string, any>;
+    expect(faq.mainEntity[0].name).toBe("How long does a sign take?");
+    expect(faq.mainEntity[0].acceptedAnswer.text).toBe("Usually 2 to 4 weeks.");
+  });
+
+  it("returns null when there are no usable questions", () => {
+    expect(faqPageSchema([])).toBeNull();
+    expect(faqPageSchema([{ question: "", answer: "" }])).toBeNull();
+  });
+
+  it("flattens plain strings and portable text alike", () => {
+    expect(portableTextToPlain("hello")).toBe("hello");
+    expect(
+      portableTextToPlain([
+        { _type: "block", children: [{ text: "a" }, { text: "b" }] },
+      ]),
+    ).toBe("ab");
+  });
+});

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -8,6 +8,8 @@ import "@/styles/ScrollBar.scss";
 import "@/styles/index.scss";
 import { NextIntlClientProvider } from "next-intl";
 import { LangType } from "@/i18n/request";
+import { JsonLd } from "@/components/JsonLd/JsonLd";
+import { localBusinessSchema, webSiteSchema } from "@/components/JsonLd/schemas";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -31,6 +33,9 @@ export default async function LocaleLayout({
           <head>
             <link rel="preload" href="/photos/BigStroke.webp" as="image" />
             <meta name="theme-color" content="#fec301" />
+            <JsonLd
+              data={[localBusinessSchema(locale), webSiteSchema(locale)]}
+            />
             <Script id="meta-pixel" strategy="afterInteractive">
               {`
                 !function(f,b,e,v,n,t,s)

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -30,6 +30,8 @@ import { ProcessAndForm } from "@/components/pages/blocks/ProcessAndForm/Process
 import { Carousel } from "@/components/pages/blocks/Carousel/Carousel";
 import { setMetadata } from "@/components/SEO";
 import { Metadata } from "next";
+import { JsonLd } from "@/components/JsonLd/JsonLd";
+import { faqPageSchema, serviceSchema } from "@/components/JsonLd/schemas";
 import {
   ServicesBlock,
   ServicesBlockProps,
@@ -107,8 +109,17 @@ export default async function HomePage({
   const form: ServiceType = "wood";
   const formData: FormTitleProps = await getFormData(form, locale);
 
+  const faqSchema = faqPageSchema(data?.collapsible?.questions);
+
   return (
     <NavWrapperServer locale={locale} theme="light" hideLogo={true}>
+      <JsonLd
+        data={
+          faqSchema
+            ? [serviceSchema(locale), faqSchema]
+            : [serviceSchema(locale)]
+        }
+      />
       {data && (
         <>
           <Hero

--- a/src/app/[locale]/projects/[slug]/page.tsx
+++ b/src/app/[locale]/projects/[slug]/page.tsx
@@ -10,6 +10,8 @@ import { redirect } from "next/navigation";
 import { LangType } from "@/i18n/request";
 import { Metadata } from "next";
 import { setMetadata } from "@/components/SEO";
+import { JsonLd } from "@/components/JsonLd/JsonLd";
+import { breadcrumbSchema } from "@/components/JsonLd/schemas";
 
 export interface WorkProps extends IWork {
   meta: ISeo;
@@ -64,9 +66,19 @@ export default async function WorkModal({
     redirect(`/${locale}${LocalPaths.PROJECTS}`);
   }
 
+  const breadcrumb = breadcrumbSchema(locale, [
+    { name: "Home", path: LocalPaths.HOME },
+    { name: "Projects", path: LocalPaths.PROJECTS },
+    {
+      name: workPageData.title || workPageData.meta?.metaTitle || slug,
+      path: `${LocalPaths.PROJECTS}/${slug}`,
+    },
+  ]);
+
   return (
     workPageData && (
       <Modal currentSlug={slug} allWorks={allWorks}>
+        <JsonLd data={breadcrumb} />
         <WorkModalContent {...workPageData} />
       </Modal>
     )

--- a/src/components/JsonLd/JsonLd.tsx
+++ b/src/components/JsonLd/JsonLd.tsx
@@ -1,0 +1,19 @@
+// src/components/JsonLd/JsonLd.tsx
+import React from "react";
+
+/**
+ * Renders a JSON-LD structured-data <script> tag.
+ * Safe to render inside a Server Component anywhere in the tree.
+ */
+export const JsonLd: React.FC<{ data: object | object[] }> = ({ data }) => {
+  return (
+    <script
+      type="application/ld+json"
+      // JSON.stringify output is escaped enough for ld+json; we additionally
+      // guard against "</script>" injection from any user/CMS-sourced strings.
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify(data).replace(/</g, "\\u003c"),
+      }}
+    />
+  );
+};

--- a/src/components/JsonLd/schemas.ts
+++ b/src/components/JsonLd/schemas.ts
@@ -1,0 +1,172 @@
+// src/components/JsonLd/schemas.ts
+//
+// Builders for schema.org JSON-LD. Every builder omits empty/unknown fields so
+// that incomplete businessInfo never produces invalid or misleading markup.
+
+import { businessInfo } from "@/data/businessInfo";
+import { LangType } from "@/i18n/request";
+import { LocalPaths } from "@/data.d";
+
+const BASE_URL = process.env.BASE_NAME || "https://www.setoxarts.com";
+
+// Stable @id for the business entity so other nodes can reference it.
+const ORG_ID = `${BASE_URL}/#business`;
+
+/** Remove keys whose value is empty ("", [], {}, null, undefined). */
+function compact<T extends Record<string, unknown>>(obj: T): Partial<T> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v === null || v === undefined || v === "") continue;
+    if (Array.isArray(v) && v.length === 0) continue;
+    if (typeof v === "object" && !Array.isArray(v) && Object.keys(v).length === 0)
+      continue;
+    out[k] = v;
+  }
+  return out as Partial<T>;
+}
+
+/** Flatten Sanity Portable Text (or plain string) into a single plain string. */
+export function portableTextToPlain(value: unknown): string {
+  if (!value) return "";
+  if (typeof value === "string") return value.trim();
+  if (!Array.isArray(value)) return "";
+  return value
+    .map((block: any) => {
+      if (typeof block === "string") return block;
+      if (block?._type === "block" && Array.isArray(block.children)) {
+        return block.children.map((c: any) => c?.text ?? "").join("");
+      }
+      return "";
+    })
+    .join("\n")
+    .replace(/\s+\n/g, "\n")
+    .trim();
+}
+
+/**
+ * LocalBusiness — the core local-SEO entity. Emitted site-wide.
+ * Omits address/geo/phone/hours until they are filled in businessInfo.
+ */
+export function localBusinessSchema(locale: LangType) {
+  const b = businessInfo;
+
+  const address = compact({
+    "@type": "PostalAddress",
+    streetAddress: b.address.streetAddress,
+    addressLocality: b.address.addressLocality,
+    addressRegion: b.address.addressRegion,
+    postalCode: b.address.postalCode,
+    addressCountry: b.address.addressCountry,
+  });
+
+  const geo =
+    b.geo.latitude && b.geo.longitude
+      ? {
+          "@type": "GeoCoordinates",
+          latitude: b.geo.latitude,
+          longitude: b.geo.longitude,
+        }
+      : "";
+
+  return compact({
+    "@context": "https://schema.org",
+    "@type": "LocalBusiness",
+    "@id": ORG_ID,
+    name: b.name,
+    legalName: b.legalName,
+    url: b.url,
+    logo: b.logo,
+    image: b.logo,
+    email: b.email,
+    description: b.description[locale] ?? b.description.en,
+    priceRange: b.priceRange,
+    foundingDate: b.foundingDate,
+    telephone: b.telephone,
+    address: Object.keys(address).length > 1 ? address : "",
+    geo,
+    areaServed: b.areaServed.map((name) => ({ "@type": "City", name })),
+    openingHours: b.openingHours,
+    sameAs: b.sameAs,
+    knowsLanguage: ["en-CA", "fr-CA"],
+  });
+}
+
+/** WebSite node — enables sitelinks / search box eligibility. */
+export function webSiteSchema(locale: LangType) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "@id": `${BASE_URL}/#website`,
+    url: BASE_URL,
+    name: businessInfo.name,
+    inLanguage: locale === "fr" ? "fr-CA" : "en-CA",
+    publisher: { "@id": ORG_ID },
+  };
+}
+
+/**
+ * Service node describing the custom LED wood sign offering, linked to the
+ * business as provider. Helps Google understand what you sell + where.
+ */
+export function serviceSchema(locale: LangType) {
+  const isFr = locale === "fr";
+  return {
+    "@context": "https://schema.org",
+    "@type": "Service",
+    serviceType: isFr
+      ? "Enseignes en bois avec LED sur mesure"
+      : "Custom LED Wood Signs",
+    provider: { "@id": ORG_ID },
+    areaServed: businessInfo.areaServed.map((name) => ({
+      "@type": "City",
+      name,
+    })),
+    description: businessInfo.description[locale] ?? businessInfo.description.en,
+    url: `${BASE_URL}/${locale}${LocalPaths.HOME}`,
+  };
+}
+
+/** BreadcrumbList from an ordered list of { name, path } items. */
+export function breadcrumbSchema(
+  locale: LangType,
+  items: { name: string; path: string }[],
+) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: items.map((item, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      name: item.name,
+      item: `${BASE_URL}/${locale}${item.path}`,
+    })),
+  };
+}
+
+/**
+ * FAQPage from a Collapsible block's questions. Answers may be Portable Text.
+ * Returns null when there are no usable Q&A pairs (so callers can skip render).
+ */
+export function faqPageSchema(
+  questions: { question: string; answer: unknown }[] | undefined,
+) {
+  const entities = (questions ?? [])
+    .map((q) => {
+      const answer = portableTextToPlain(q.answer);
+      if (!q.question || !answer) return null;
+      return {
+        "@type": "Question",
+        name: q.question,
+        acceptedAnswer: { "@type": "Answer", text: answer },
+      };
+    })
+    .filter(Boolean);
+
+  if (entities.length === 0) return null;
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: entities,
+  };
+}

--- a/src/data/businessInfo.ts
+++ b/src/data/businessInfo.ts
@@ -1,0 +1,77 @@
+// src/data/businessInfo.ts
+//
+// Single source of truth for Seto x Arts business identity.
+// Used to generate structured data (JSON-LD) for SEO / rich results,
+// and safe to reuse anywhere the NAP (name/address/phone) is needed.
+//
+// IMPORTANT: Values left as empty strings are intentionally OMITTED from the
+// emitted JSON-LD (see schemas.ts). Fill in the TODO fields below with the
+// exact data from your Google Business Profile so the schema stays consistent
+// with what Google already knows about you (NAP consistency matters for local
+// SEO). Do NOT invent values — an omitted field is better than a wrong one.
+
+const BASE_URL = process.env.BASE_NAME || "https://www.setoxarts.com";
+
+export const businessInfo = {
+  // Matches the Google Business Profile name exactly (NAP consistency + keyword).
+  name: "Seto x Arts | Custom LED Wood Signs",
+  legalName: "Seto x Arts",
+  url: BASE_URL,
+
+  // Date the business opened (from Google Business Profile). Empty = omitted.
+  foundingDate: "2024-09-01",
+
+  // Self-hosted logo (1600x1600). Used as Organization/LocalBusiness logo + image.
+  logo: `${BASE_URL}/photos/SocialLogo.png`,
+
+  // Public business email (matches EMAIL_BUSINESS).
+  email: "contact@setoxarts.com",
+
+  // EN + FR short descriptions (sourced from public/llms.txt).
+  description: {
+    en:
+      "Seto x Arts designs and builds high-end custom LED wood signs for businesses. Each piece is handcrafted using layered real wood and integrated LED lighting to create depth, contrast, and a strong visual identity.",
+    fr:
+      "Seto x Arts conçoit et fabrique des enseignes en bois avec éclairage LED haut de gamme, entièrement sur mesure. Chaque pièce est fabriquée à la main avec du vrai bois et un éclairage intégré pour créer de la profondeur, du contraste et une forte identité visuelle.",
+  },
+
+  // Premium positioning. "$$$" signals high-end to Google. Leave "" to omit.
+  priceRange: "$$$",
+
+  // Cities / regions served (service-area business). Matches GBP service area.
+  areaServed: ["Montreal", "Laval", "Fabreville", "Greater Montreal", "Quebec"],
+
+  // --- TODO: fill from your Google Business Profile for full local SEO ---
+  // Public phone in international format, e.g. "+1-514-555-0123". Empty = omitted.
+  telephone: "+1-438-405-8699",
+
+  // Physical address. If you run a service-area business and don't want a
+  // public street address, leave streetAddress "" — the schema will fall back
+  // to city/region only, which is fine. Empty fields are omitted.
+  address: {
+    streetAddress: "4886 Bd Sainte-Rose", // TODO e.g. "123 Rue Example"
+    addressLocality: "Laval", // city
+    addressRegion: "QC",
+    postalCode: "H7R 2B7", // TODO
+    addressCountry: "CA",
+  },
+
+  // Geo coordinates from your GBP map pin. Empty = omitted.
+  geo: {
+    latitude: "45.55619579260311", // TODO e.g. "45.5917"
+    longitude: "-73.86603541349362", // TODO e.g. "-73.7073"
+  },
+
+  // Opening hours in schema.org format. Empty array = omitted.
+  // Example: ["Mo-Fr 09:00-17:00", "Sa 10:00-15:00"]
+  openingHours: ["Mo-Fr 10:00-21:00"] as string[],
+
+  // Social / authority profiles (used for sameAs — helps entity recognition).
+  // TODO: confirm/replace the Instagram + Facebook URLs with your real handles.
+  sameAs: [
+    "https://www.instagram.com/seto.arts", // TODO confirm handle
+    "https://www.facebook.com/people/Seto-x-Arts/61557749380017", // TODO confirm handle
+  ],
+} as const;
+
+export type BusinessInfo = typeof businessInfo;


### PR DESCRIPTION
Add LocalBusiness, WebSite, Service, FAQPage and BreadcrumbList schemas to improve organic/local search visibility and rich-result eligibility.

- businessInfo.ts: single source of truth for NAP, synced to Google Business Profile (name, phone, address, geo, hours, founding date, service area incl. Fabreville). Empty fields are omitted from output.
- JsonLd component + schema builders with empty-field compaction and Portable Text -> plain text for FAQ answers.
- Inject LocalBusiness + WebSite site-wide, Service + FAQPage on home, BreadcrumbList on project pages.
- Add schema unit tests (11 cases) for local validation.