### PR TITLE
fix(seo): return real 404 for dead URLs + self-canonical homepage

### DIFF
--- a/src/app/[locale]/[...not-found]/page.tsx
+++ b/src/app/[locale]/[...not-found]/page.tsx
@@ -1,21 +1,9 @@
-import { notFoundPageQuery } from "@/app/api/generateSanityQueries";
-import { fetchPage } from "@/app/api/fetchPage";
-import { NotFoundComp } from "@/components/pages/NotFound";
-import { INotFound } from "@/data.d";
-import { LangType } from "@/i18n/request";
-import NavWrapperServer from "@/components/navbar/NavWrapper/NavWrapperServer";
+import { notFound } from "next/navigation";
 
-export default async function NotFound({
-  params,
-}: {
-  params: Promise<{ locale: LangType }>;
-}) {
-  const { locale } = await params;
-  const notFoundQuery = notFoundPageQuery("en");
-  const notFoundPageData: INotFound = await fetchPage(notFoundQuery);
-  return (
-    <NavWrapperServer locale={locale} theme="light">
-      <NotFoundComp data={notFoundPageData} locale={"en"} />
-    </NavWrapperServer>
-  );
+// Any unmatched path under a locale (e.g. dead URLs from the old site
+// structure) lands here. Calling notFound() renders the locale-level
+// not-found.tsx UI WITH a real HTTP 404 status — instead of a "200 OK"
+// soft-404, which Google never drops and keeps re-crawling.
+export default function CatchAllNotFound() {
+  notFound();
 }

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -17,7 +17,12 @@ export const setMetadata = ({
   crawl = true,
 }: SEOProps): Metadata => {
   const baseUrl = process.env.BASE_NAME;
-  const canonicalUrl = `${baseUrl}/${locale}${path}`;
+  // The home path is "/", which would produce ".../en/" (trailing slash).
+  // Pages are served without a trailing slash, so the homepage's canonical must
+  // self-reference as ".../en" — otherwise Google treats /en as a non-canonical
+  // "alternate" of /en/ (which redirects), and may not index it directly.
+  const normalizedPath = path === "/" ? "" : path;
+  const canonicalUrl = `${baseUrl}/${locale}${normalizedPath}`;
   return {
     title: metaTitle || "Seto X Arts",
     description: metaDesc || "Explore creative work by Seto X Arts.",
@@ -50,9 +55,9 @@ export const setMetadata = ({
     alternates: {
       canonical: canonicalUrl,
       languages: {
-        "en-CA": `https://www.setoxarts.com/en${path}`,
-        "fr-CA": `https://www.setoxarts.com/fr${path}`,
-        "x-default": `https://www.setoxarts.com${path}`,
+        "en-CA": `https://www.setoxarts.com/en${normalizedPath}`,
+        "fr-CA": `https://www.setoxarts.com/fr${normalizedPath}`,
+        "x-default": `https://www.setoxarts.com${normalizedPath || "/"}`,
       },
     },
   };


### PR DESCRIPTION
- Catch-all [...not-found] now calls notFound() so unmatched/legacy URLs return HTTP 404 (was 200, which Google flagged as Soft 404 and kept re-crawling instead of dropping). Keeps the existing not-found UI.
- SEO.setMetadata: normalize the home path ("/") so the homepage canonical
  + hreflang self-reference as ".../en" instead of ".../en/" (the trailing slash made Google treat /en as a non-canonical alternate of a redirect).